### PR TITLE
Remove DM signals assignment from DDR4 Datacenter platform

### DIFF
--- a/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
+++ b/litex_boards/platforms/antmicro_datacenter_ddr4_test_board.py
@@ -51,8 +51,6 @@ _io = [
         Subsignal("act_n",   Pins("Y8"), IOStandard("SSTL12_DCI")),
         Subsignal("alert_n", Pins("AE10"), IOStandard("SSTL12_DCI")),
         Subsignal("par",     Pins("AE13"), IOStandard("SSTL12_DCI")),
-        Subsignal("dm",      Pins("AF3 AE5 AD6 AC6 AF2 AE3 AE6 AD5"),
-            IOStandard("SSTL12_DCI")),
         Subsignal("dq",      Pins(
                 "W11  Y11  V7   Y7   V11  V9   V8   W8",
                 "U2   V6   Y2   Y3   U5   U4   W3   Y1",


### PR DESCRIPTION
Data Masks (DM) are unsupported on x4 devices and wrong pins were assigned.

It is PR just for discussion purposes.